### PR TITLE
Recommend using a passphrase

### DIFF
--- a/SSH.md
+++ b/SSH.md
@@ -43,7 +43,7 @@ Generating public/private ed25519 key pair.
 Enter file in which to save the key (/Users/username/.ssh/id_ed25519):  
 ```
 
-You will then be asked to provide an optional passphrase. This can be used to make your key even more secure, but for this lesson you can skip it by hitting enter twice.
+You will then be asked to provide an passphrase. Protecting your keys with a passphrase is optional but highly recommended.  Don't hesitate to use a long passphrase, you'll only have to type it once to unlock a key.
 
 ```
 Enter passphrase (empty for no passphrase):  

--- a/SSH.md
+++ b/SSH.md
@@ -72,6 +72,8 @@ ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFEKiimOpcayfHhlbjmnIBAUX74FY/o20k9yFA16XOLm
 
 Copy the contents of the output to your clipboard.
 
+**Be careful**: do not copy the content of your *private* key, but your *public* key. Your public key ends with `.pub`.
+
 Login to github.com and bring up your account settings by clicking on your profile photo (top right) and selecting **Settings**. Click on **SSH and GPG keys** (left sidebar), and then click on the green button 'New SSH key' or '**Add SSH key**'.
 
 ![](./assets/ssh-key.png)


### PR DESCRIPTION
I believe we should recommend learners to use a passphrase. Especially because the keys that they will create at this stage will probably be used in other contexts beyond this workshop.