### PR TITLE
Emphasize which terminal emulator to use depending on which sytem

### DIFF
--- a/SSH.md
+++ b/SSH.md
@@ -12,6 +12,11 @@ The procedure below only need to be executed once per GitHub account and for eac
 The first step in using SSH authorization with GitHub is to generate your own key pair. 
 However, you might already have an SSH key pair on your machine. You can check to see if one exists by moving to your `.ssh` directory and listing the contents.
 
+On windows, open **Git Bash** (start menu -> Git Bash). On MacOS, open
+the **Terminal** app. On Linux, open your distribution's (or any
+other) terminal emulator. Enter the following commands one after the
+other (hitting ENTER after each command).
+
 To do this on Windows:  
 open Git Bash and type the following  
 ```

--- a/installing_software.md
+++ b/installing_software.md
@@ -30,12 +30,25 @@ Git is one of the most popular version control systems in the world. It is free 
 
 **Configure git**
 
-After installing git, you need to tell it who you are. Open a terminal window (**cmd.exe on windows**) and type the following
+After installing git, you need to tell it who you are.
+
+By default, git is used through a _command line interface_. We'll use
+git in this way now in order to perform its initial and minimal
+configuration. In the remaining of this tutorial, you'll learn how to
+use git through Rstudio instead of a command line interface.
+
+On windows, open **Git Bash** (start menu -> Git Bash). On MacOS, open
+the **Terminal** app. On Linux, open your distribution's (or any
+other) terminal emulator. Enter the following commands one after the
+other (hitting ENTER after each command).
 
 ```
 git config --global user.email "you@youremail.com"
 git config --global user.name "Your Name"
 ```
+
+Be sur to replace `you@youremail.com` and `Your Name` by your email
+address and your name.
 
 On successful completion, you should see no output from these commands.  
 


### PR DESCRIPTION
Just making clearer with terminal emulator people should use depending on what platform.

Particularly, students were instructed to configure git using cmd.exe in the "Installing software part", although the ssh key part mentions Git Bash.

This removes any mention of cmd.exe and instructs Windows users to use Git Bash.